### PR TITLE
Update Auth URL to create a limited scope token

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 		<div class='connect'>
 			<h1><i class="fa fa-line-chart"></i> Grasshopper</h1>
 			<h2><a href="https://developer.wordpress.com/docs/api/">WordPress.com REST API</a> + <a href="http://d3js.org/">D3.js</a> = <i class="fa fa-heart"></i></h2>
-			<a href="https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=40443&redirect_uri=https://automattic.github.io/grasshopper/" class="authorize"><img src="//s0.wp.com/i/wpcc-button.png" width="231"></a>
+			<a href="https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=40443&redirect_uri=https://automattic.github.io/grasshopper/&scope=stats%20sites" class="authorize"><img src="//s0.wp.com/i/wpcc-button.png" width="231"></a>
 		</div>
 
 		<!-- The good stuff goes here. -->


### PR DESCRIPTION
The WP.com API has been updated to support limited scopes for tokens.
This app only needs access to the sites and stats group, so we're setting the token scope to that.

There is no change in app functionality.

For scope documentation, see https://developer.wordpress.com/docs/oauth2/